### PR TITLE
fix(ci): use latest to prevent `find` undefined error at coverage step

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -51,6 +51,9 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
 
+  # TODO: It could be disabled for now, as it's flaky and actions-rs is currently unmaintained
+  # Should update to use the tarpaulin directly with another toolchain instead of actions-rs
+
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
@@ -64,4 +67,5 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: "0.15.0"
           args: '--ignore-tests'


### PR DESCRIPTION
- fix `Error: Cannot read property 'find' of undefined` from coverage/tarpaulin CI step.