### PR TITLE
feat(deployment): add digital-ocean deployment config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-aux"
+version = "4.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c599b3fd89a75e0c18d6d2be693ddb12cccaf771db4ff9e39097104808a014c0"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2588,7 @@ dependencies = [
  "reqwest",
  "secrecy",
  "serde",
+ "serde-aux",
  "sqlx",
  "time",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ once_cell = "1.17.0"
 time = "0.3.19"
 secrecy = { version = "0.8.0", features = ["serde"] }
 tracing-actix-web = "0.7.2"
+serde-aux = "4.1.2"
 
 [dependencies.sqlx]
 version = "0.6"

--- a/configuration/local.yaml
+++ b/configuration/local.yaml
@@ -1,2 +1,4 @@
 application:
   host: 127.0.0.1
+database:
+  require_ssl: false

--- a/configuration/production.yaml
+++ b/configuration/production.yaml
@@ -1,2 +1,4 @@
 application:
   host: 0.0.0.0
+database:
+  require_ssl: true

--- a/spec.yaml
+++ b/spec.yaml
@@ -1,0 +1,40 @@
+name: zero2prod
+# Check https://www.digitalocean.com/docs/app-platform/#regional-availability
+# for a list of all the available options.
+# You can get region slugs from
+# https://www.digitalocean.com/docs/platform/availability-matrix/
+# They must specified lowercased.
+# `fra` stands for Frankfurt (Germany - EU)
+# TODO: (@oleonardolima) Check and update for a better region
+region: fra
+services:
+  - name: zero2prod
+    # Relative to the repository root
+    dockerfile_path: Dockerfile
+    source_dir: .
+    github:
+      # Depending on when you created the repository,
+      # the default branch on GitHub might have been named `master`
+      branch: main
+      # Deploy a new version on every commit to `main`!
+      # Continuous Deployment, here we come!
+      deploy_on_push: true
+      # !!! Fill in with your details
+      # e.g. LukeMathWalker/zero-to-production
+      repo: oleonardolima/zero2prod
+    # Active probe used by DigitalOcean's to ensure our application is healthy
+    health_check:
+      # The path to our health check endpoint!
+      # It turned out to be useful in the end!
+      http_path: /health_check
+    # The port the application will be listening on for incoming requests
+    # It should match what we specified in our configuration/production.yaml file!
+    http_port: 8000
+    # For production workloads we'd go for at least two!
+    # But let's try to keep the bill under control for now...
+    instance_count: 1
+    # TODO: (@oleonardolima) Check and update for better instance size, for better performance and cost
+    instance_size_slug: basic-xxs
+    # All incoming requests should be routed to our app
+    routes:
+      - path: /

--- a/spec.yaml
+++ b/spec.yaml
@@ -38,3 +38,29 @@ services:
     # All incoming requests should be routed to our app
     routes:
       - path: /
+    envs:
+      - key: APP_DATABASE__USERNAME
+        scope: RUN_TIME
+        value: ${newsletter.USERNAME}
+      - key: APP_DATABASE__PASSWORD
+        scope: RUN_TIME
+        value: ${newsletter.PASSWORD}
+      - key: APP_DATABASE__HOST
+        scope: RUN_TIME
+        value: ${newsletter.HOSTNAME}
+      - key: APP_DATABASE__PORT
+        scope: RUN_TIME
+        value: ${newsletter.PORT}
+      - key: APP_DATABASE__DATABASE_NAME
+        scope: RUN_TIME
+        value: ${newsletter.DATABASE}
+databases:
+  # PG = Postgres
+  - engine: PG
+    # Database name
+    name: newsletter
+    # Again, let's keep the bill lean
+    num_nodes: 1
+    size: db-s-dev-database
+    # Postgres version - using the latest here
+    version: "12"

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -1,4 +1,9 @@
 use secrecy::{ExposeSecret, Secret};
+use serde_aux::field_attributes::deserialize_number_from_string;
+use sqlx::{
+    postgres::{PgConnectOptions, PgSslMode},
+    ConnectOptions,
+};
 
 #[derive(serde::Deserialize)]
 pub struct Settings {
@@ -8,6 +13,7 @@ pub struct Settings {
 
 #[derive(serde::Deserialize)]
 pub struct ApplicationSettings {
+    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
     pub host: String,
 }
@@ -17,32 +23,34 @@ pub struct DatabaseSettings {
     pub username: String,
     pub password: Secret<String>,
     pub host: String,
+    #[serde(deserialize_with = "deserialize_number_from_string")]
     pub port: u16,
     pub database_name: String,
+    pub require_ssl: bool,
 }
 
 impl DatabaseSettings {
-    /// Generates a Postgres database connection string
-    pub fn connection_string(&self) -> Secret<String> {
-        Secret::new(format!(
-            "postgres://{}:{}@{}:{}/{}",
-            self.username,
-            self.password.expose_secret(),
-            self.host,
-            self.port,
-            self.database_name
-        ))
+    /// Generates a Postgres database [PgConnectOptions]
+    pub fn with_db(&self) -> PgConnectOptions {
+        let mut options = self.without_db().database(&self.database_name);
+        options.log_statements(tracing::log::LevelFilter::Trace);
+        options
     }
 
-    /// Generates a Postgres instance connection string
-    pub fn connection_string_without_db(&self) -> Secret<String> {
-        Secret::new(format!(
-            "postgres://{}:{}@{}:{}",
-            self.username,
-            self.password.expose_secret(),
-            self.host,
-            self.port
-        ))
+    /// Generates a Postgres instance [PgConnectOptions]
+    pub fn without_db(&self) -> PgConnectOptions {
+        let ssl_mode = if self.require_ssl {
+            PgSslMode::Require
+        } else {
+            PgSslMode::Prefer
+        };
+
+        PgConnectOptions::new()
+            .host(&self.host)
+            .username(&self.username)
+            .password(self.password.expose_secret())
+            .port(self.port)
+            .ssl_mode(ssl_mode)
     }
 }
 
@@ -67,6 +75,11 @@ pub fn get_configuration() -> Result<Settings, config::ConfigError> {
         .add_source(config::File::from(
             configuration_directory.join(environment_filename),
         ))
+        .add_source(
+            config::Environment::with_prefix("APP")
+                .prefix_separator("_")
+                .separator("__"),
+        )
         .build()?;
 
     // try to convert the configuration values it read into Settings type/struct

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 use std::net::TcpListener;
 
-use secrecy::ExposeSecret;
 use sqlx::postgres::PgPoolOptions;
 use zero2prod::{
     configuration::get_configuration,
@@ -16,8 +15,7 @@ async fn main() -> std::io::Result<()> {
     let configuration = get_configuration().expect("Failed to read configuration.");
     let connection_pool = PgPoolOptions::new()
         .acquire_timeout(std::time::Duration::from_secs(2))
-        .connect_lazy(configuration.database.connection_string().expose_secret())
-        .expect("Failed to connect to Postgres.");
+        .connect_lazy_with(configuration.database.with_db());
 
     let listener = TcpListener::bind(format!(
         "{}:{}",

--- a/tests/health_check.rs
+++ b/tests/health_check.rs
@@ -1,5 +1,5 @@
 use once_cell::sync::Lazy;
-use secrecy::ExposeSecret;
+
 use sqlx::{Connection, Executor, PgConnection, PgPool};
 use std::{net::TcpListener, vec};
 use uuid::Uuid;
@@ -51,17 +51,16 @@ async fn spawn_app() -> TestApp {
 
 async fn configure_database(config: &DatabaseSettings) -> PgPool {
     // create database
-    let mut connection =
-        PgConnection::connect(config.connection_string_without_db().expose_secret())
-            .await
-            .expect("Failed to connect to Postgres instance.");
+    let mut connection = PgConnection::connect_with(&config.without_db())
+        .await
+        .expect("Failed to connect to Postgres instance.");
     connection
         .execute(format!(r#"CREATE DATABASE "{}";"#, config.database_name).as_str())
         .await
         .expect("Failed to create database.");
 
     // migrate database
-    let connection_pool = PgPool::connect(config.connection_string().expose_secret())
+    let connection_pool = PgPool::connect_with(config.with_db())
         .await
         .expect("Failed to connect to Postgres database.");
     sqlx::migrate!("./migrations")


### PR DESCRIPTION
It adds the spec.yaml file for continuous deployment at Digital Ocean Apps Platform, refactors the code to use the database settings values from environment variables if they exist. It also refactors the `DatabaseSettings` to use `PgConnectOptions` instead of a connection string, as it adds more flexibility for its settings values.

 --

629a9e9 wip: add initial spec to digitalocean deployment
eca765f  feat+refactor: add db to spec.yaml and configuration.rs